### PR TITLE
Improve test coverage (partly)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,10 +6,8 @@ omit =
     # omit everything in /usr
     /usr/*
     # omit this single file
-    beacon_api/__init__.py
-    beacon_api/utils/__init__.py
-    beacon_api/conf/__init__.py
-    beacon_api/api/__init__.py
+    beacon_search/config.py
+    beacon_auth/config.py
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/beacon_aggregator/app.py
+++ b/beacon_aggregator/app.py
@@ -107,8 +107,8 @@ async def query(beacon, q, access_token):
             LOG.info(str(e))
 
 
-def main():
-    """Start the web server."""
+def init():
+    """Initialise server."""
     server = web.Application()
     # Set this to the domain of the GUI to only allow requests from that source
     DOMAIN = os.environ.get('CORS_ALLOWED_DOMAIN', 'localhost:3000')
@@ -122,7 +122,12 @@ def main():
     server.router.add_routes(routes)
     for route in list(server.router.routes()):
         cors.add(route)
-    web.run_app(server,
+    return server
+
+
+def main():
+    """Start the web server."""
+    web.run_app(init(),
                 host=os.environ.get('APP_HOST', 'localhost'),
                 port=os.environ.get('APP_PORT', 8080))
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ pytest-cov
 coveralls
 flake8
 flake8-docstrings
+asynctest

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,51 @@
+from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+import asynctest
+from beacon_aggregator.app import init, main
+from unittest import mock
+from aiohttp import web
+
+
+class AppTestCase(AioHTTPTestCase):
+    """Test for Web app.
+
+    Testing web app endpoints.
+    """
+
+    async def get_application(self):
+        """Retrieve web Application for test."""
+        return init()
+
+    @unittest_run_loop
+    async def test_health(self):
+        """Test the info endpoint.
+
+        The status should always be 200.
+        """
+        resp = await self.client.request("GET", "/health")
+        assert 200 == resp.status
+
+
+class TestBasicFunctionsApp(asynctest.TestCase):
+    """Test App Base.
+
+    Testing basic functions from web app.
+    """
+
+    def setUp(self):
+        """Initialise fixtures."""
+        pass
+
+    def tearDown(self):
+        """Remove setup variables."""
+        pass
+
+    @mock.patch('beacon_aggregator.app.web')
+    def test_main(self, mock_webapp):
+        """Should start the webapp."""
+        main()
+        mock_webapp.run_app.assert_called()
+
+    def test_init(self):
+        """Test init type."""
+        server = init()
+        self.assertIs(type(server), web.Application)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,20 @@
+import unittest
+
+# from unittest import mock
+
+from beacon_auth.wsgi import application
+
+
+class TestSearchAPI(unittest.TestCase):
+    """Test beacon-search API functions and endpoints."""
+
+    def setUp(self):
+        """Execute this method on start."""
+        application.config['TESTING'] = True
+        application.config['WTF_CSRF_ENABLED'] = False
+        application.config['DEBUG'] = False
+        self.app = application.test_client()
+
+    def tearDown(self):
+        """Execute this method after each test."""
+        pass

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,11 @@ passenv = TRAVIS TRAVIS_*
 deps =
     -rtests/requirements.txt
     -rbeacon_search/requirements.txt
+    -rbeacon_aggregator/requirements.txt
+    -rbeacon_auth/requirements.txt
 # Stop after first failure
 commands = flake8 .
-           pytest -x --cov beacon_search --cov beacon_aggregator --cov beacon_auth tests/
+           pytest -x --cov beacon_search --cov beacon_aggregator --cov beacon_auth --cov-report html tests/
            python {toxinidir}/tests/coveralls.py
 
 [travis]


### PR DESCRIPTION
Aim to improve test coverage of the python applications.
We are omitting `beacon_mock` as it is provided for testing purposes only, not to be used in production.

partly do #7 