### PR TITLE
More query options

### DIFF
--- a/beacon-ui/app/assets/main.css
+++ b/beacon-ui/app/assets/main.css
@@ -502,3 +502,7 @@ md-autocomplete#custom-template {
 	/* color: #F57C20; */
 	/* font-weight: bold; */
 }
+
+.filter-hits {
+	float: left;
+}

--- a/beacon-ui/app/view/view.html
+++ b/beacon-ui/app/view/view.html
@@ -33,7 +33,7 @@
               </md-input-container>
               <md-autocomplete flex md-selected-item="ctrl.selectedItem" md-input-name="autocompleteField" md-search-text="ctrl.searchText" md-items="item in ctrl.querySearch(ctrl.searchText)" md-selected-item="ctrl.selectedItem" md-item-text="item.name"
                 md-min-length="0" class="searchBox" md-input-minlength="2" md-input-id="autoCompleteId" md-delay="300" md-menu-class="autocomplete-custom-template" md-menu-container-class="custom-container" md-floating-label="Chromosome : Position ReferenceBase > AlternateBase|VariantType">
-
+                
                 <md-item-template>
                   <div class="item-type">
                     <span> {{item.type}} </span>
@@ -70,7 +70,12 @@
         <a href="" ng-click="searchExample('gene')">Gene</a> /
         <a href="" ng-click="searchExample('variant')">Variant</a>
       </div> -->
-      <div id="searchExample"><a href="" ng-click="searchExample('variant')">Show example search</a></div>
+      <div id="searchExample">
+          <md-checkbox class="md-primary filter-hits" ng-model="hitsOnly">
+              Show hits only
+          </md-checkbox>
+          <a href="" ng-click="searchExample('variant')">Show example search</a>
+      </div>
     </div>
     <hr />
   </div>

--- a/beacon-ui/app/view/view.html
+++ b/beacon-ui/app/view/view.html
@@ -229,7 +229,7 @@
                 <td>{{ dataset.variantType }}</td>
                 <td>{{ dataset.referenceBases }}</td>
                 <td>{{ dataset.alternateBases }}</td>
-                <td>{{ dataset.sampleCount }}</td>
+                <td>{{ dataset.variantCount }}</td>
                 <td>{{ dataset.frequency }}</td>
 
               </tr>

--- a/beacon-ui/app/view/view.html
+++ b/beacon-ui/app/view/view.html
@@ -32,7 +32,7 @@
                 </md-select>
               </md-input-container>
               <md-autocomplete flex md-selected-item="ctrl.selectedItem" md-input-name="autocompleteField" md-search-text="ctrl.searchText" md-items="item in ctrl.querySearch(ctrl.searchText)" md-selected-item="ctrl.selectedItem" md-item-text="item.name"
-                md-min-length="0" class="searchBox" md-input-minlength="2" md-input-id="autoCompleteId" md-delay="300" md-menu-class="autocomplete-custom-template" md-menu-container-class="custom-container" md-floating-label="Chromosome : Position ReferenceBase > AlternateBase">
+                md-min-length="0" class="searchBox" md-input-minlength="2" md-input-id="autoCompleteId" md-delay="300" md-menu-class="autocomplete-custom-template" md-menu-container-class="custom-container" md-floating-label="Chromosome : Position ReferenceBase > AlternateBase|VariantType">
 
                 <md-item-template>
                   <div class="item-type">
@@ -78,7 +78,7 @@
     <!-- Please select a disease or gene from the autocomplete suggestions, or search for a variant directly (see examples search above).
     <hr /> -->
     For variant search use the following search structure (including spaces):
-    <em>{Chromosome} : {Position} {ReferenceBases} > {AlternateBases}</em>
+    <em>{Chromosome} : {Position} {ReferenceBases} > {AlternateBases|VariantType}</em>
   </div>
   <div ng-if="ctrl.selectedItem && ctrl.searchClick && url.includes('disease') && ctrl.message.status == 200">
     <div class="row result-row">

--- a/beacon-ui/app/view/view.js
+++ b/beacon-ui/app/view/view.js
@@ -32,7 +32,6 @@ angular.module('beaconApp.view', ['ngRoute', 'ngMaterial', 'ngMessages', 'ngCook
   
   // Determines scope of query true=HIT, false=ALL
   $scope.hitsOnly = true;
-  console.log($scope.hitsOnly);
 
   // $scope.object = {alertType : true}
     // $scope.alertType = true;
@@ -55,7 +54,9 @@ angular.module('beaconApp.view', ['ngRoute', 'ngMaterial', 'ngMessages', 'ngCook
       $scope.alertType = false;
   };
 
-  that.regexp = /^(X|Y|MT|[1-9]|1[0-9]|2[0-2]) \: (\d+) ([ATCGN]+) \> ([ATCGN]+)$/i;
+  // Old regexp for bases only
+  // that.regexp = /^(X|Y|MT|[1-9]|1[0-9]|2[0-2]) \: (\d+) ([ATCGN]+) \> ([ATCGN]+)$/i;
+  // New regex that adds variant types
   that.regexp2 = /^(X|Y|MT|[1-9]|1[0-9]|2[0-2]) \: (\d+) ([ATCGN]+) \> (DEL:ME|INS:ME|DUP:TANDEM|DUP|DEL|INS|INV|CNV|SNP|MNP|[ATCGN]+)$/i;
   that.varTypes = ["DEL:ME", "INS:ME", "DUP:TANDEM", "DUP", "DEL", "INS", "INV", "CNV", "SNP", "MNP"]
 
@@ -156,27 +157,23 @@ angular.module('beaconApp.view', ['ngRoute', 'ngMaterial', 'ngMessages', 'ngCook
       var params = that.searchText.match(that.regexp2)
       // Determine scope of query
       var inclDataResp = 'HIT';
+      var searchType = '';
       if ($scope.hitsOnly == false) {
         inclDataResp = 'ALL';
       }
       // Check if we are dealing with bases or variant types
       if (that.varTypes.indexOf(params[4]) >= 0) {
         // Variant type
-        $scope.url = $scope.aggregatorUrl + 'assemblyId=' +
-                    $scope.assembly.selected +
-                    '&referenceName=' + params[1] + '&start=' + params[2] +
-                    '&referenceBases=' + params[3] + '&variantType=' + params[4] +
-                    '&includeDatasetResponses=' + inclDataResp;
-        console.log($scope.url);
+        searchType = '&variantType=' + params[4];
       } else {
         // Alternate base
-        $scope.url = $scope.aggregatorUrl + 'assemblyId=' +
+        searchType = '&alternateBases=' + params[4];
+      }
+      $scope.url = $scope.aggregatorUrl + 'assemblyId=' +
                     $scope.assembly.selected +
                     '&referenceName=' + params[1] + '&start=' + params[2] +
-                    '&referenceBases=' + params[3] + '&alternateBases=' + params[4] +
+                    '&referenceBases=' + params[3] + searchType +
                     '&includeDatasetResponses=' + inclDataResp;
-        console.log($scope.url);
-      }
     } else {
       console.log('search type unselected');
     }

--- a/beacon-ui/app/view/view.js
+++ b/beacon-ui/app/view/view.js
@@ -52,6 +52,8 @@ angular.module('beaconApp.view', ['ngRoute', 'ngMaterial', 'ngMessages', 'ngCook
   };
 
   that.regexp = /^(X|Y|MT|[1-9]|1[0-9]|2[0-2]) \: (\d+) ([ATCGN]+) \> ([ATCGN]+)$/i;
+  that.regexp2 = /^(X|Y|MT|[1-9]|1[0-9]|2[0-2]) \: (\d+) ([ATCGN]+) \> (DEL:ME|INS:ME|DUP:TANDEM|DUP|DEL|INS|INV|CNV|SNP|MNP|[ATCGN]+)$/i;
+  that.varTypes = ["DEL:ME", "INS:ME", "DUP:TANDEM", "DUP", "DEL", "INS", "INV", "CNV", "SNP", "MNP"]
 
   $scope.checkLogin = function() {
     if($cookies.get('access_token')) {
@@ -134,7 +136,7 @@ angular.module('beaconApp.view', ['ngRoute', 'ngMaterial', 'ngMessages', 'ngCook
     that.message = 'loading';
     that.searchClick = true;
     $scope.itemsPerPage = 10;
-    if (that.regexp.test(that.searchText)) {
+    if (that.regexp2.test(that.searchText)) {
       that.selectedItem = {type: 'variant', name: that.searchText}
 
     }
@@ -147,12 +149,25 @@ angular.module('beaconApp.view', ['ngRoute', 'ngMaterial', 'ngMessages', 'ngCook
     // } else
     if (that.selectedItem && that.selectedItem.type == 'variant') {
       that.triggerCredentials = true;
-      var params = that.searchText.match(that.regexp)
-      $scope.url = $scope.aggregatorUrl + 'assemblyId=' +
-                   $scope.assembly.selected +
-                   '&referenceName=' + params[1] + '&start=' + params[2] +
-                   '&referenceBases=' + params[3] + '&alternateBases=' + params[4] +
-                   '&includeDatasetResponses=HIT';
+      var params = that.searchText.match(that.regexp2)
+      // Check if we are dealing with bases or variant types
+      if (that.varTypes.indexOf(params[4]) >= 0) {
+        // Variant type
+        $scope.url = $scope.aggregatorUrl + 'assemblyId=' +
+                    $scope.assembly.selected +
+                    '&referenceName=' + params[1] + '&start=' + params[2] +
+                    '&referenceBases=' + params[3] + '&variantType=' + params[4] +
+                    '&includeDatasetResponses=HIT';
+        console.log($scope.url);
+      } else {
+        // Alternate base
+        $scope.url = $scope.aggregatorUrl + 'assemblyId=' +
+                    $scope.assembly.selected +
+                    '&referenceName=' + params[1] + '&start=' + params[2] +
+                    '&referenceBases=' + params[3] + '&alternateBases=' + params[4] +
+                    '&includeDatasetResponses=HIT';
+        console.log($scope.url);
+      }
     } else {
       console.log('search type unselected');
     }

--- a/beacon-ui/app/view/view.js
+++ b/beacon-ui/app/view/view.js
@@ -199,7 +199,9 @@ angular.module('beaconApp.view', ['ngRoute', 'ngMaterial', 'ngMessages', 'ngCook
     // } else
     if (searchtype == 'variant') {
       // Maybe add examples for other chromosomes later when we have more datasets
-      var variants = ['MT : 10 T > C', 'MT : 7600 G > A', 'MT : 195 TTACTAAAGT > CCACTAAAGT', 'MT : 14037 A > G']
+      var variants = ['MT : 10 T > C', 'MT : 7600 G > A', 'MT : 195 TTACTAAAGT > CCACTAAAGT', 'MT : 14037 A > G',
+                      '1 : 104431390 C > INS', '19 : 36585458 A > INS', '19 : 36909437 C > DUP', '1 : 2847963 G > DUP',
+                      '1 : 1393861 T > CNV', '1 : 85910910 C > CNV', '1 : 218144328 A > INV']
       // Select example variant from list at random
       that.searchText = variants[Math.floor(Math.random()*variants.length)];
       document.querySelector('#autoCompleteId').focus();

--- a/beacon-ui/app/view/view.js
+++ b/beacon-ui/app/view/view.js
@@ -28,7 +28,11 @@ angular.module('beaconApp.view', ['ngRoute', 'ngMaterial', 'ngMessages', 'ngCook
 		$scope.baseUrl = data.baseUrl;
     $scope.aggregatorUrl = data.aggregatorUrl;
     $scope.autocompleteUrl = $scope.baseUrl + '/autocomplete?';
-	});
+  });
+  
+  // Determines scope of query true=HIT, false=ALL
+  $scope.hitsOnly = true;
+  console.log($scope.hitsOnly);
 
   // $scope.object = {alertType : true}
     // $scope.alertType = true;
@@ -150,6 +154,11 @@ angular.module('beaconApp.view', ['ngRoute', 'ngMaterial', 'ngMessages', 'ngCook
     if (that.selectedItem && that.selectedItem.type == 'variant') {
       that.triggerCredentials = true;
       var params = that.searchText.match(that.regexp2)
+      // Determine scope of query
+      var inclDataResp = 'HIT';
+      if ($scope.hitsOnly == false) {
+        inclDataResp = 'ALL';
+      }
       // Check if we are dealing with bases or variant types
       if (that.varTypes.indexOf(params[4]) >= 0) {
         // Variant type
@@ -157,7 +166,7 @@ angular.module('beaconApp.view', ['ngRoute', 'ngMaterial', 'ngMessages', 'ngCook
                     $scope.assembly.selected +
                     '&referenceName=' + params[1] + '&start=' + params[2] +
                     '&referenceBases=' + params[3] + '&variantType=' + params[4] +
-                    '&includeDatasetResponses=HIT';
+                    '&includeDatasetResponses=' + inclDataResp;
         console.log($scope.url);
       } else {
         // Alternate base
@@ -165,7 +174,7 @@ angular.module('beaconApp.view', ['ngRoute', 'ngMaterial', 'ngMessages', 'ngCook
                     $scope.assembly.selected +
                     '&referenceName=' + params[1] + '&start=' + params[2] +
                     '&referenceBases=' + params[3] + '&alternateBases=' + params[4] +
-                    '&includeDatasetResponses=HIT';
+                    '&includeDatasetResponses=' + inclDataResp;
         console.log($scope.url);
       }
     } else {


### PR DESCRIPTION
Fixes #23 

Allows usage of symbolic ALT alleles in search bar, e.g.
```
1 : 100 C > INS
1 : 100 C > DUP
```

Adds a filter button to determine scope of query to return only HITs or ALL (hits, misses, none).