### PR TITLE
Sock it to me

### DIFF
--- a/beacon-ui/app/view/view.html
+++ b/beacon-ui/app/view/view.html
@@ -195,8 +195,8 @@
   </div> -->
   <!-- <div ng-if="ctrl.selectedItem && ctrl.searchClick && checkLogin() && url.includes('referenceName') && ctrl.message.status == 200" class="row result-row"> -->
 
-  <div ng-if="ctrl.selectedItem && ctrl.searchClick && url.includes('referenceName') && ctrl.message.status == 200" class="row result-row">
-    <md-card class="resultCard" ng-repeat="datum in ctrl.message.data | filter:hitsOnly">
+  <div ng-if="ctrl.selectedItem && ctrl.searchClick && url.includes('referenceName')" class="row result-row">
+    <md-card class="resultCard" ng-repeat="datum in ctrl.message | filter:hitsOnly">
       <md-card-header class="cardItem" id="topCard">
         <md-card-header-text>
           <span class="md-title">{{datum.beaconId}} <span class="beacon-api-version">{{datum.apiVersion}}</span></span>
@@ -251,7 +251,7 @@
       </md-card-actions>
     </md-card>
   </div>
-  <div ng-if="ctrl.message == 'loading'" layout="row" layout-sm="column" layout-align="space-around">
+  <div ng-if="ctrl.loading" layout="row" layout-sm="column" layout-align="space-around">
     <md-progress-circular md-mode="indeterminate"></md-progress-circular>
   </div>
   <div style="text-align:center">

--- a/beacon-ui/app/view/view.html
+++ b/beacon-ui/app/view/view.html
@@ -238,8 +238,8 @@
                 <td>{{ dataset.variantType }}<span ng-if="!dataset.variantType">{{ datum.alleleRequest.variantType }}</span></td>
                 <td>{{ dataset.referenceBases }}<span ng-if="!dataset.referenceBases">{{ datum.alleleRequest.referenceBases }}</span></td>
                 <td>{{ dataset.alternateBases }}<span ng-if="!dataset.alternateBases">{{ datum.alleleRequest.alternateBases }}</span></td>
-                <td>{{ dataset.variantCount }}</td>
-                <td>{{ dataset.frequency }}</td>
+                <td>{{ dataset.variantCount > 0 ? dataset.variantCount : "n/a" }}</td>
+                <td>{{ dataset.frequency > 0 ? dataset.frequency : "n/a" }}</td>
 
               </tr>
             </tbody>

--- a/beacon_aggregator/app.py
+++ b/beacon_aggregator/app.py
@@ -119,7 +119,7 @@ def main():
     """Start the web server."""
     web.run_app(init(),
                 host=os.environ.get('APP_HOST', 'localhost'),
-                port=os.environ.get('APP_PORT', 5000))
+                port=os.environ.get('APP_PORT', 8080))
 
 
 if __name__ == '__main__':

--- a/beacon_aggregator/app.py
+++ b/beacon_aggregator/app.py
@@ -100,7 +100,7 @@ async def query(beacon, q, access_token, ws):
                     # Send error to websocket client
                     return await ws.send_str(json.dumps(str({"beaconUrl": beacon,
                                                              "queryParams": q,
-                                                             "responseStatus": response.status})))       
+                                                             "responseStatus": response.status})))
         except Exception as e:
             LOG.info(str(e))
 

--- a/beacon_aggregator/requirements.txt
+++ b/beacon_aggregator/requirements.txt
@@ -1,2 +1,4 @@
 aiohttp
 aiohttp_cors
+asyncio
+uvloop


### PR DESCRIPTION
Change `aiohttp.web.StreamResponse` to `aiohttp.web.WebSocketResponse` to eliminate the issue of unclosed stream bracket `]` in case of aggregator failure. Now the aggregator just serves the beacon response over as `string` in `dictionary` form.

- [x] Fixes #22
- [x] Websocket server in beacon-aggregator
- [x] Websocket client at beacon-ui
- [x] Spinner keeps spinning as long as socket is waiting for more results, stops when socket is closed

Additionally:
- [x] 0 is rendered n/a in the response table

Currently uses unsecure `ws://` socket. After rahti-deployment, test if secure socket `wss://` works directly.

![](https://puu.sh/Cj1M0/ef4d758a77.gif)
_click to enlarge_